### PR TITLE
Fix broken link typo by renaming the file.

### DIFF
--- a/JavaScript/README.md
+++ b/JavaScript/README.md
@@ -8,6 +8,6 @@
 - [Codecademy JavaScript Cheatsheet](./codecademy-js.pdf)
 - [JavaScript Cheatsheet](./Javascript_cheatsheet.pdf)
 - [Javascript Dom Cheatsheet](./JavaScript_DOM_Cheatsheet.pdf)
-- [Javascript ES6 Cheatsheet](./es6_chatesheet.pdf)
+- [Javascript ES6 Cheatsheet](./es6_cheatsheet.pdf)
 - [Javascript Array Reduce Cheatsheet](./javascript-array-reduce.png)
 - [Javascript Cheatsheet from overAPI](https://overapi.com/javascript)


### PR DESCRIPTION
This PR solves issue #116.
- Fixed the link by updating the filename in README.md