### PR TITLE
Markdown cheatsheet filename and link changed

### DIFF
--- a/C/README.md
+++ b/C/README.md
@@ -2,4 +2,4 @@
 
 ## Cheatsheets:
 
-- [C++ Basics & advance](./C-Cheatsheet.pdf)
+- [The C Cheat Sheet](./C-CheatSheet.pdf)


### PR DESCRIPTION
Hi,

The current C cheatsheets markdown was wrong: bad cheatsheet title and file link.

Thanks